### PR TITLE
Depend on tiltToyData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ URL: https://2degreesinvesting.github.io/tiltWorkflows/,
     https://github.com/2DegreesInvesting/tiltWorkflows
 BugReports: https://github.com/2DegreesInvesting/tiltWorkflows/issues
 Depends: 
-    tiltIndicatorAfter
+    tiltIndicatorAfter,
+    tiltToyData (>= 0.0.0.9005)
 Imports: 
     usethis
 Suggests: 
@@ -22,7 +23,8 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Remotes: 
-    2DegreesInvesting/tiltIndicatorAfter
+    2DegreesInvesting/tiltIndicatorAfter,
+    2DegreesInvesting/tiltToyData
 Config/Needs/website: rmarkdown
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,3 +2,4 @@
 
 export(use_workflow)
 importFrom(tiltIndicatorAfter,unnest_product)
+importFrom(tiltToyData,toy_files)

--- a/R/tiltWorkflows-package.R
+++ b/R/tiltWorkflows-package.R
@@ -3,5 +3,6 @@
 
 ## usethis namespace: start
 #' @importFrom tiltIndicatorAfter unnest_product
+#' @importFrom tiltToyData toy_files
 ## usethis namespace: end
 NULL


### PR DESCRIPTION
Relates to #7 

This PR moves tiltToyData to depends so that all toy datasets are automatically available to the user  when they call `library(tiltWorkflows)`.


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
