### PR TITLE
`use_workflow()` now automatically opens the file if run interactively

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     purrr,
     rappdirs,
     readr,
+    rlang,
     tibble,
     usethis
 Suggests: 

--- a/R/use_workflow.R
+++ b/R/use_workflow.R
@@ -16,7 +16,9 @@
 #' # Note: Running this will write "profile_emissions.Rmd" to your working directory
 #' use_workflow("profile_emissions.Rmd")
 #' }
-use_workflow <- function(template, save_as = template, open = FALSE) {
+use_workflow <- function(template = "profile.Rmd",
+                         save_as = template,
+                         open = rlang::is_interactive()) {
   usethis::use_template(
     template,
     save_as = save_as,

--- a/man/use_workflow.Rd
+++ b/man/use_workflow.Rd
@@ -5,7 +5,11 @@
 \alias{workflows}
 \title{List and use workflows}
 \usage{
-use_workflow(template, save_as = template, open = FALSE)
+use_workflow(
+  template = "profile.Rmd",
+  save_as = template,
+  open = rlang::is_interactive()
+)
 
 workflows()
 }


### PR DESCRIPTION
Relates to #1 

This PR automatically opens a workflow file in interactive sessions. It mimics the behavior of functions in usethis, e.g. `use_news_md()`.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
