### PR TITLE
Allow to run chunks in different order

### DIFF
--- a/R/map_chunks.R
+++ b/R/map_chunks.R
@@ -12,7 +12,7 @@ map_chunks <- function(data,
   job |>
     pick_undone() |>
     dchunkr::order_rows(.fun = order_rows)
-    select("data", "file") |>
+  select("data", "file") |>
     future_pwalk(\(data, file) .f(data, ...) |> write_rds(file), .progress = TRUE)
 
   map_df(job$file, read_rds)

--- a/R/map_chunks.R
+++ b/R/map_chunks.R
@@ -11,8 +11,8 @@ map_chunks <- function(data,
 
   job |>
     pick_undone() |>
-    dchunkr::order_rows(.fun = order_rows)
-  select("data", "file") |>
+    dchunkr::order_rows(.fun = order_rows) |>
+    select("data", "file") |>
     future_pwalk(\(data, file) .f(data, ...) |> write_rds(file), .progress = TRUE)
 
   map_df(job$file, read_rds)

--- a/R/map_chunks.R
+++ b/R/map_chunks.R
@@ -1,4 +1,9 @@
-map_chunks <- function(data, .f, ..., .by, chunks, cache_dir) {
+map_chunks <- function(data,
+                       .f, ...,
+                       .by,
+                       chunks,
+                       cache_dir,
+                       order_rows = "identity") {
   parent <- rm_namespace(deparse(substitute(.f)))
   job <- data |>
     nest_chunk(.by = .by, chunks = chunks) |>
@@ -6,6 +11,7 @@ map_chunks <- function(data, .f, ..., .by, chunks, cache_dir) {
 
   job |>
     pick_undone() |>
+    dchunkr::order_rows(.fun = order_rows)
     select("data", "file") |>
     future_pwalk(\(data, file) .f(data, ...) |> write_rds(file), .progress = TRUE)
 

--- a/R/map_chunks.R
+++ b/R/map_chunks.R
@@ -3,7 +3,7 @@ map_chunks <- function(data,
                        .by,
                        chunks,
                        cache_dir,
-                       order_rows = "identity") {
+                       order = "identity") {
   parent <- rm_namespace(deparse(substitute(.f)))
   job <- data |>
     nest_chunk(.by = .by, chunks = chunks) |>
@@ -11,7 +11,7 @@ map_chunks <- function(data,
 
   job |>
     pick_undone() |>
-    dchunkr::order_rows(.fun = order_rows) |>
+    dchunkr::order_rows(.fun = order) |>
     select("data", "file") |>
     future_pwalk(\(data, file) .f(data, ...) |> write_rds(file), .progress = TRUE)
 

--- a/R/profile.R
+++ b/R/profile.R
@@ -11,6 +11,7 @@ profile_emissions <- function(companies,
                               high_threshold = 2 / 3) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
+  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_emissions(
@@ -28,6 +29,7 @@ profile_emissions <- function(companies,
       companies,
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
+      order_rows = order_rows,
       .by = "companies_id",
       .f = tiltIndicatorAfter::profile_emissions,
       co2 = co2,
@@ -55,6 +57,7 @@ profile_emissions_upstream <- function(companies,
                                        high_threshold = 2 / 3) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
+  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_emissions_upstream(
@@ -74,6 +77,7 @@ profile_emissions_upstream <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
+      order_rows = order_rows,
       .f = tiltIndicatorAfter::profile_emissions_upstream,
       co2 = co2,
       europages_companies = europages_companies,
@@ -100,6 +104,7 @@ profile_sector <- function(companies,
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
+  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_sector(
@@ -118,6 +123,7 @@ profile_sector <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
+      order_rows = order_rows,
       .f = tiltIndicatorAfter::profile_sector,
       scenarios = scenarios,
       europages_companies = europages_companies,
@@ -145,6 +151,7 @@ profile_sector_upstream <- function(companies,
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
+  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_sector_upstream(
@@ -165,6 +172,7 @@ profile_sector_upstream <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
+      order_rows = order_rows,
       .f = tiltIndicatorAfter::profile_sector_upstream,
       scenarios = scenarios,
       inputs = inputs,

--- a/R/profile.R
+++ b/R/profile.R
@@ -11,7 +11,7 @@ profile_emissions <- function(companies,
                               high_threshold = 2 / 3) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
-  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
+  order <- getOption("tiltWorkflows.order", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_emissions(
@@ -29,7 +29,7 @@ profile_emissions <- function(companies,
       companies,
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
-      order_rows = order_rows,
+      order = order,
       .by = "companies_id",
       .f = tiltIndicatorAfter::profile_emissions,
       co2 = co2,
@@ -57,7 +57,7 @@ profile_emissions_upstream <- function(companies,
                                        high_threshold = 2 / 3) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
-  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
+  order <- getOption("tiltWorkflows.order", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_emissions_upstream(
@@ -77,7 +77,7 @@ profile_emissions_upstream <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
-      order_rows = order_rows,
+      order = order,
       .f = tiltIndicatorAfter::profile_emissions_upstream,
       co2 = co2,
       europages_companies = europages_companies,
@@ -104,7 +104,7 @@ profile_sector <- function(companies,
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
-  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
+  order <- getOption("tiltWorkflows.order", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_sector(
@@ -123,7 +123,7 @@ profile_sector <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
-      order_rows = order_rows,
+      order = order,
       .f = tiltIndicatorAfter::profile_sector,
       scenarios = scenarios,
       europages_companies = europages_companies,
@@ -151,7 +151,7 @@ profile_sector_upstream <- function(companies,
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
   chunks <- abort_zero_chunks(getOption("tiltWorkflows.chunks"))
   cache_dir <- getOption("tiltWorkflows.cache_dir", user_cache_dir("tiltWorkflows"))
-  order_rows <- getOption("tiltWorkflows.order_rows", "identity")
+  order <- getOption("tiltWorkflows.order", "identity")
 
   if (identical(chunks, 1)) {
     tiltIndicatorAfter::profile_sector_upstream(
@@ -172,7 +172,7 @@ profile_sector_upstream <- function(companies,
       .by = "companies_id",
       chunks = handle_chunks(companies),
       cache_dir = cache_dir,
-      order_rows = order_rows,
+      order = order,
       .f = tiltIndicatorAfter::profile_sector_upstream,
       scenarios = scenarios,
       inputs = inputs,

--- a/inst/extdata/cleanup.Rmd
+++ b/inst/extdata/cleanup.Rmd
@@ -1,12 +1,24 @@
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/inst/extdata/cleanup.Rmd
+++ b/inst/extdata/cleanup.Rmd
@@ -9,7 +9,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/inst/extdata/cleanup.Rmd
+++ b/inst/extdata/cleanup.Rmd
@@ -12,10 +12,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 
@@ -28,4 +28,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/inst/extdata/output.Rmd
+++ b/inst/extdata/output.Rmd
@@ -4,4 +4,3 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-

--- a/inst/extdata/setup.Rmd
+++ b/inst/extdata/setup.Rmd
@@ -42,7 +42,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/extdata/setup.Rmd
+++ b/inst/extdata/setup.Rmd
@@ -42,6 +42,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/extdata/yaml-01-all.Rmd
+++ b/inst/extdata/yaml-01-all.Rmd
@@ -3,7 +3,7 @@ title: "{workflow}"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/extdata/yaml-01-all.Rmd
+++ b/inst/extdata/yaml-01-all.Rmd
@@ -3,7 +3,7 @@ title: "{workflow}"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/extdata/yaml-01-all.Rmd
+++ b/inst/extdata/yaml-01-all.Rmd
@@ -3,6 +3,7 @@ title: "{workflow}"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -3,6 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -59,6 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -155,13 +157,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -154,7 +154,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -165,7 +165,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -60,7 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -169,10 +169,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 
@@ -185,4 +185,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -181,7 +181,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -3,6 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -60,6 +61,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -171,13 +173,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -185,10 +185,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 
@@ -201,4 +201,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -61,7 +61,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -170,7 +170,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -162,7 +162,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -151,7 +151,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -60,7 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -3,6 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -59,6 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -152,13 +154,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -166,10 +166,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 
@@ -182,4 +182,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -62,7 +62,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -181,7 +181,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -185,10 +185,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 
@@ -201,4 +201,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -170,7 +170,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -3,6 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -61,6 +62,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -171,13 +173,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/tests/testthat/_snaps/generate_templates_and_articles.md
+++ b/tests/testthat/_snaps/generate_templates_and_articles.md
@@ -8,6 +8,7 @@
       output: github_document
       params:
         chunks: NULL
+        order_chunks: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -28,6 +29,7 @@
       output: github_document
       params:
         chunks: NULL
+        order_chunks: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -49,6 +51,7 @@
       output: github_document
       params:
         chunks: NULL
+        order_chunks: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -69,6 +72,7 @@
       output: github_document
       params:
         chunks: NULL
+        order_chunks: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"

--- a/tests/testthat/_snaps/generate_templates_and_articles.md
+++ b/tests/testthat/_snaps/generate_templates_and_articles.md
@@ -8,7 +8,7 @@
       output: github_document
       params:
         chunks: NULL
-        order_chunks: "sample"
+        order:: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -29,7 +29,7 @@
       output: github_document
       params:
         chunks: NULL
-        order_chunks: "sample"
+        order:: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -51,7 +51,7 @@
       output: github_document
       params:
         chunks: NULL
-        order_chunks: "sample"
+        order:: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -72,7 +72,7 @@
       output: github_document
       params:
         chunks: NULL
-        order_chunks: "sample"
+        order:: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"

--- a/tests/testthat/_snaps/generate_templates_and_articles.md
+++ b/tests/testthat/_snaps/generate_templates_and_articles.md
@@ -8,7 +8,7 @@
       output: github_document
       params:
         chunks: NULL
-        order:: "sample"
+        order: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -29,7 +29,7 @@
       output: github_document
       params:
         chunks: NULL
-        order:: "sample"
+        order: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -51,7 +51,7 @@
       output: github_document
       params:
         chunks: NULL
-        order:: "sample"
+        order: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"
@@ -72,7 +72,7 @@
       output: github_document
       params:
         chunks: NULL
-        order:: "sample"
+        order: "sample"
         input: "input"
         output: "output"
         europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -3,6 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -59,6 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -155,13 +157,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -154,7 +154,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -165,7 +165,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -60,7 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -169,10 +169,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -185,4 +185,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -181,7 +181,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -201,4 +201,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -3,6 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -60,6 +61,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -171,13 +173,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -185,10 +185,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -61,7 +61,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -170,7 +170,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_emissions_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -182,4 +182,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -162,7 +162,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -166,10 +166,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -151,7 +151,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -60,7 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -3,6 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -59,6 +60,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -152,13 +154,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -62,7 +62,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
-  tiltWorkflows.order_rows = params$order_rows,
+  tiltWorkflows.order = params$order,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order_chunks: "sample"
+  order:: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -181,7 +181,7 @@ Here is the cache that allows you to resume after interruptions.
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
 
-* The order of files is determined by `params$order_row`.
+* The order of files is determined by `params$order`.
 
 ```{r}
 user_cache_dir("tiltWorkflows") |>

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -201,4 +201,3 @@ library(rappdirs)
 
 dir_delete(user_cache_dir("tiltWorkflows/PROFILE-DIRECTORY-YOU-WANT-TO-DELETE"))
 ```
-

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -3,7 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
-  order:: "sample"
+  order: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -185,10 +185,10 @@ dir_tree(user_cache_dir("tiltWorkflows"))
 * The order of files is determined by `params$order_row`.
 
 ```{r}
-user_cache_dir("tiltWorkflows") |> 
-  dir_ls(type = "file", recurse = TRUE) |> 
-  file_info() |> 
-  arrange(modification_time) |> 
+user_cache_dir("tiltWorkflows") |>
+  dir_ls(type = "file", recurse = TRUE) |>
+  file_info() |>
+  arrange(modification_time) |>
   select(path)
 ```
 

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -170,7 +170,6 @@ The results at product and company level are now saved in the output/ directory.
 # NOTE: If other workflows run before this one, this shows the results of all
 params$output |> dir_tree()
 ```
-
 ## Cleanup
 
 Here is the cache that allows you to resume after interruptions. 

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -3,6 +3,7 @@ title: "profile_sector_upstream.Rmd"
 output: github_document
 params:
   chunks: NULL
+  order_chunks: "sample"
   input: "input"
   output: "output"
   europages_companies: "europages_companies.csv"
@@ -61,6 +62,7 @@ params
 ```{r}
 options(
   tiltWorkflows.chunks = params$chunks,
+  tiltWorkflows.order_rows = params$order_rows,
   # Read data quietly
   readr.show_col_types = FALSE,
   # Make printed output wider
@@ -171,13 +173,25 @@ params$output |> dir_tree()
 
 ## Cleanup
 
-Here is the cache that allows you to resume after interruptions. The number of
-`chunks` determines the number of files.
+Here is the cache that allows you to resume after interruptions. 
+
+* The number of files is determined by `params$chunks`.
 
 ```{r eval=dir_exists(user_cache_dir("tiltWorkflows"))}
 # NOTE: If other workflows run before this one, this shows the cache of all
 dir_tree(user_cache_dir("tiltWorkflows"))
 ```
+
+* The order of files is determined by `params$order_row`.
+
+```{r}
+user_cache_dir("tiltWorkflows") |> 
+  dir_ls(type = "file", recurse = TRUE) |> 
+  file_info() |> 
+  arrange(modification_time) |> 
+  select(path)
+```
+
 
 If you want to recompute some result, you must first delete the relevant cache:
 


### PR DESCRIPTION
Relates to #50 

This allows users to run the same workflow from different sessions/computers in a complementary way and complete faster.

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
