### PR TITLE
Resolve R-CMD check after adding `co2_lower` and `co2_upper` in `tiltIndicatorAfter`

### DIFF
--- a/man/profile_emissions.Rd
+++ b/man/profile_emissions.Rd
@@ -86,6 +86,7 @@ result |> unnest_company()
 }
 \seealso{
 Other top-level functions: 
-\code{\link[tiltIndicatorAfter]{profile_sector}()}
+\code{\link[tiltIndicatorAfter]{profile_sector}()},
+\code{\link[tiltIndicatorAfter]{score_transition_risk}()}
 }
 \keyword{internal}

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -89,6 +89,7 @@ result |> unnest_company()
 }
 \seealso{
 Other top-level functions: 
-\code{\link[tiltIndicatorAfter]{profile_sector}()}
+\code{\link[tiltIndicatorAfter]{profile_sector}()},
+\code{\link[tiltIndicatorAfter]{score_transition_risk}()}
 }
 \keyword{internal}

--- a/man/profile_sector.Rd
+++ b/man/profile_sector.Rd
@@ -91,6 +91,7 @@ result |> unnest_company()
 }
 \seealso{
 Other top-level functions: 
-\code{\link[tiltIndicatorAfter]{profile_emissions}()}
+\code{\link[tiltIndicatorAfter]{profile_emissions}()},
+\code{\link[tiltIndicatorAfter]{score_transition_risk}()}
 }
 \keyword{internal}

--- a/man/profile_sector_upstream.Rd
+++ b/man/profile_sector_upstream.Rd
@@ -97,6 +97,7 @@ result |> unnest_company()
 }
 \seealso{
 Other top-level functions: 
-\code{\link[tiltIndicatorAfter]{profile_emissions}()}
+\code{\link[tiltIndicatorAfter]{profile_emissions}()},
+\code{\link[tiltIndicatorAfter]{score_transition_risk}()}
 }
 \keyword{internal}


### PR DESCRIPTION
closes #122 
It relates to this [PR](https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/163) now as the one which showed the same R-CMD check fail is merged now.

----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
