### PR TITLE
Ensure test-output isn't affected by randomly-generated data

### DIFF
--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -43,7 +43,9 @@ test_that("outputs the same as tiltIndicatorAfter", {
     suppressMessages()
 
     remove_unimportant_differences <- function(data) {
+      # The order of rows is unimportant
       arranged <- dplyr::arrange(data, companies_id)
+      # The specific value of randomly-generated columns are unimportant
       product <- arranged |> unnest_product() |> select(-matches("co2e"))
       company <- arranged |> unnest_company() |> select(-matches("co2e"))
       tiltIndicator::nest_levels(product, company)

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -27,6 +27,7 @@ test_that("outputs the same as tiltIndicatorAfter", {
     tiltWorkflows.cache_dir = withr::local_tempdir(),
     tiltWorkflows.chunks = 3
   ))
+
   masked <- profile_emissions(
     companies,
     products,
@@ -41,7 +42,17 @@ test_that("outputs the same as tiltIndicatorAfter", {
     # is_null
     suppressMessages()
 
-  expect_equal(dplyr::arrange(masked, companies_id), dplyr::arrange(original, companies_id))
+    remove_unimportant_differences <- function(data) {
+      arranged <- dplyr::arrange(data, companies_id)
+      product <- arranged |> unnest_product() |> select(-matches("co2e"))
+      company <- arranged |> unnest_company() |> select(-matches("co2e"))
+      tiltIndicator::nest_levels(product, company)
+    }
+
+  expect_equal(
+    original |> remove_unimportant_differences(),
+    masked |> remove_unimportant_differences()
+  )
 })
 
 test_that("with `chunks = 0` throws an informative error", {

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -46,14 +46,14 @@ test_that("outputs the same as tiltIndicatorAfter", {
       # The order of rows is unimportant
       arranged <- dplyr::arrange(data, companies_id)
       # The specific value of randomly-generated columns are unimportant
-      product <- arranged |> unnest_product() |> select(-matches("co2e"))
-      company <- arranged |> unnest_company() |> select(-matches("co2e"))
+      product <- select(unnest_product(arranged), -matches("co2e"))
+      company <- select(unnest_company(arranged), -matches("co2e"))
       tiltIndicator::nest_levels(product, company)
     }
 
   expect_equal(
-    original |> remove_unimportant_differences(),
-    masked |> remove_unimportant_differences()
+    remove_unimportant_differences(original),
+    remove_unimportant_differences(masked)
   )
 })
 

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -42,15 +42,15 @@ test_that("outputs the same as tiltIndicatorAfter", {
     # is_null
     suppressMessages()
 
-    remove_unimportant_differences <- function(data) {
-      # The order of rows is unimportant
-      arranged <- dplyr::arrange(data, companies_id)
-      # The specific value of randomly-generated columns are unimportant
-      generated_randomly <- "co2e"
-      product <- select(unnest_product(arranged), -matches(generated_randomly))
-      company <- select(unnest_company(arranged), -matches(generated_randomly))
-      tiltIndicator::nest_levels(product, company)
-    }
+  remove_unimportant_differences <- function(data) {
+    # The order of rows is unimportant
+    arranged <- dplyr::arrange(data, companies_id)
+    # The specific value of randomly-generated columns are unimportant
+    generated_randomly <- "co2e"
+    product <- select(unnest_product(arranged), -matches(generated_randomly))
+    company <- select(unnest_company(arranged), -matches(generated_randomly))
+    tiltIndicator::nest_levels(product, company)
+  }
 
   expect_equal(
     remove_unimportant_differences(original),

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -46,8 +46,9 @@ test_that("outputs the same as tiltIndicatorAfter", {
       # The order of rows is unimportant
       arranged <- dplyr::arrange(data, companies_id)
       # The specific value of randomly-generated columns are unimportant
-      product <- select(unnest_product(arranged), -matches("co2e"))
-      company <- select(unnest_company(arranged), -matches("co2e"))
+      generated_randomly <- "co2e"
+      product <- select(unnest_product(arranged), -matches(generated_randomly))
+      company <- select(unnest_company(arranged), -matches(generated_randomly))
       tiltIndicator::nest_levels(product, company)
     }
 


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/tiltIndicatorAfter/pull/155

tiltIndicatorAfter#155 introduced data generated randomly. This PR reacts to that change to ensure tests are stable.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
