### PR TITLE
`profile*()` gains `isic` and deprecates `isic_tilt` as in tiltIndicatorAfter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     future,
     glue,
     knitr,
+    lifecycle,
     purrr,
     rappdirs,
     readr,

--- a/R/profile.R
+++ b/R/profile.R
@@ -6,9 +6,18 @@ profile_emissions <- function(companies,
                               europages_companies,
                               ecoinvent_activities,
                               ecoinvent_europages,
-                              isic_tilt,
+                              isic,
+                              isic_tilt = lifecycle::deprecated(),
                               low_threshold = 1 / 3,
                               high_threshold = 2 / 3) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017", "profile_emissions(isic_tilt)",
+      "profile_emissions(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -21,7 +30,7 @@ profile_emissions <- function(companies,
       europages_companies = europages_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -37,7 +46,7 @@ profile_emissions <- function(companies,
       europages_companies = europages_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -53,9 +62,18 @@ profile_emissions_upstream <- function(companies,
                                        ecoinvent_activities,
                                        ecoinvent_inputs,
                                        ecoinvent_europages,
-                                       isic_tilt,
+                                       isic,
+                                       isic_tilt = lifecycle::deprecated(),
                                        low_threshold = 1 / 3,
                                        high_threshold = 2 / 3) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017", "profile_emissions_upstream(isic_tilt)",
+      "profile_emissions_upstream(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -69,7 +87,7 @@ profile_emissions_upstream <- function(companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -86,7 +104,7 @@ profile_emissions_upstream <- function(companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -101,9 +119,18 @@ profile_sector <- function(companies,
                            europages_companies,
                            ecoinvent_activities,
                            ecoinvent_europages,
-                           isic_tilt,
+                           isic,
+                           isic_tilt = lifecycle::deprecated(),
                            low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                            high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017", "profile_sector(isic_tilt)",
+      "profile_sector(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -116,7 +143,7 @@ profile_sector <- function(companies,
       europages_companies = europages_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -132,7 +159,7 @@ profile_sector <- function(companies,
       europages_companies = europages_companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -149,9 +176,18 @@ profile_sector_upstream <- function(companies,
                                     ecoinvent_activities,
                                     ecoinvent_inputs,
                                     ecoinvent_europages,
-                                    isic_tilt,
+                                    isic,
+                                    isic_tilt = lifecycle::deprecated(),
                                     low_threshold = ifelse(scenarios$year == 2030, 1 / 9, 1 / 3),
                                     high_threshold = ifelse(scenarios$year == 2030, 2 / 9, 2 / 3)) {
+  if (lifecycle::is_present(isic_tilt)) {
+    lifecycle::deprecate_warn(
+      "0.0.0.9017", "profile_sector_upstream(isic_tilt)",
+      "profile_sector_upstream(isic)"
+    )
+    isic <- isic_tilt
+  }
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -166,7 +202,7 @@ profile_sector_upstream <- function(companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )
@@ -184,7 +220,7 @@ profile_sector_upstream <- function(companies,
       ecoinvent_activities = ecoinvent_activities,
       ecoinvent_inputs = ecoinvent_inputs,
       ecoinvent_europages = ecoinvent_europages,
-      isic = isic_tilt,
+      isic = isic,
       low_threshold = low_threshold,
       high_threshold = high_threshold
     )

--- a/man/profile_emissions.Rd
+++ b/man/profile_emissions.Rd
@@ -10,7 +10,8 @@ profile_emissions(
   europages_companies,
   ecoinvent_activities,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = 1/3,
   high_threshold = 2/3
 )
@@ -23,6 +24,8 @@ profile_emissions(
 \item{ecoinvent_activities}{Dataframe. Activities from ecoinvent.}
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
+
+\item{isic}{Dataframe. ISIC data.}
 
 \item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -11,7 +11,8 @@ profile_emissions_upstream(
   ecoinvent_activities,
   ecoinvent_inputs,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = 1/3,
   high_threshold = 2/3
 )
@@ -26,6 +27,8 @@ profile_emissions_upstream(
 \item{ecoinvent_inputs}{Dataframe. Upstream products from ecoinvent.}
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
+
+\item{isic}{Dataframe. ISIC data.}
 
 \item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 

--- a/man/profile_sector.Rd
+++ b/man/profile_sector.Rd
@@ -10,7 +10,8 @@ profile_sector(
   europages_companies,
   ecoinvent_activities,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = ifelse(scenarios$year == 2030, 1/9, 1/3),
   high_threshold = ifelse(scenarios$year == 2030, 2/9, 2/3)
 )
@@ -21,6 +22,8 @@ profile_sector(
 \item{ecoinvent_activities}{Dataframe. Activities from ecoinvent.}
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
+
+\item{isic}{Dataframe. ISIC data.}
 
 \item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 

--- a/man/profile_sector_upstream.Rd
+++ b/man/profile_sector_upstream.Rd
@@ -12,7 +12,8 @@ profile_sector_upstream(
   ecoinvent_activities,
   ecoinvent_inputs,
   ecoinvent_europages,
-  isic_tilt,
+  isic,
+  isic_tilt = lifecycle::deprecated(),
   low_threshold = ifelse(scenarios$year == 2030, 1/9, 1/3),
   high_threshold = ifelse(scenarios$year == 2030, 2/9, 2/3)
 )
@@ -27,6 +28,8 @@ profile_sector_upstream(
 \item{ecoinvent_inputs}{Dataframe. Upstream products from ecoinvent.}
 
 \item{ecoinvent_europages}{Dataframe. Mapper between europages and ecoinvent.}
+
+\item{isic}{Dataframe. ISIC data.}
 
 \item{isic_tilt}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -1,3 +1,25 @@
+test_that("has identical interface to tiltIndicatorAfter", {
+  expect_equal(
+    formalArgs(profile_emissions),
+    formalArgs(tiltIndicatorAfter::profile_emissions)
+  )
+
+  expect_equal(
+    formalArgs(profile_emissions_upstream),
+    formalArgs(tiltIndicatorAfter::profile_emissions_upstream)
+  )
+
+  expect_equal(
+    formalArgs(profile_sector),
+    formalArgs(tiltIndicatorAfter::profile_sector)
+  )
+
+  expect_equal(
+    formalArgs(profile_sector_upstream),
+    formalArgs(tiltIndicatorAfter::profile_sector_upstream)
+  )
+})
+
 test_that("outputs the same as tiltIndicatorAfter", {
   withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(


### PR DESCRIPTION
Closes #129

This PR:

* Adds the new argument `isic` that was added a while ago to tiltIndicatorAfter.
*  deprecates the argument `isic_tilt` that was already deprecated in tiltIndicatorAfter
* Ensures tiltWorkflows has the same interface than tiltIndicatorAfter.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
