### PR TITLE
In tests DRY options via setup.R

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,2 +1,3 @@
 # https://testthat.r-lib.org/articles/special-files.html#setup-files
+withr::local_options(readr.show_col_types = FALSE, .local_envir = teardown_env())
 withr::local_options(tiltIndicatorAfter.verbose = FALSE, .local_envir = teardown_env())

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,2 @@
+# https://testthat.r-lib.org/articles/special-files.html#setup-files
+withr::local_options(tiltIndicatorAfter.verbose = FALSE, .local_envir = teardown_env())

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -21,7 +21,6 @@ test_that("has identical interface to tiltIndicatorAfter", {
 })
 
 test_that("outputs the same as tiltIndicatorAfter", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.cache_dir = withr::local_tempdir(),
@@ -81,7 +80,6 @@ test_that("outputs the same as tiltIndicatorAfter", {
 })
 
 test_that("with `chunks = 0` throws an informative error", {
-  withr::local_options(readr.show_col_types = FALSE)
   invalid <- 0
   withr::local_options(list(
     readr.show_col_types = FALSE,
@@ -107,7 +105,6 @@ test_that("with `chunks = 0` throws an informative error", {
 })
 
 test_that("with `chunks` passed as a character throws no error", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.chunks = as.character(3),
@@ -134,7 +131,6 @@ test_that("with `chunks` passed as a character throws no error", {
 })
 
 test_that("with `chunks = NULL` warns auto set chunks", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.cache_dir = withr::local_tempdir()
@@ -161,7 +157,6 @@ test_that("with `chunks = NULL` warns auto set chunks", {
 })
 
 test_that("with `chunks = ''` warns auto set chunks", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.chunks = "",
@@ -189,7 +184,6 @@ test_that("with `chunks = ''` warns auto set chunks", {
 })
 
 test_that("with `cache_dir = NULL` throws no error", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.chunks = 3
@@ -215,7 +209,6 @@ test_that("with `cache_dir = NULL` throws no error", {
 })
 
 test_that("with `cache_dir = ''` throws no error", {
-  withr::local_options(readr.show_col_types = FALSE)
   withr::local_options(list(
     readr.show_col_types = FALSE,
     tiltWorkflows.cache_dir = "",
@@ -242,7 +235,6 @@ test_that("with `cache_dir = ''` throws no error", {
 })
 
 test_that("with `order = 'rev'` the chunks work in reverse order", {
-  withr::local_options(readr.show_col_types = FALSE)
   tmp_cache <- local_tempfile()
   withr::local_options(list(
     readr.show_col_types = FALSE,


### PR DESCRIPTION
Many tests use the same options. This PR removes duplication by calling the options once in tests/testhat/setup.R

https://testthat.r-lib.org/articles/special-files.html#setup-files

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] Assign a reviewer.
