### PR TITLE
Each workflow now uses default `*threshold`s

### DIFF
--- a/inst/extdata/code-profile_emissions.Rmd
+++ b/inst/extdata/code-profile_emissions.Rmd
@@ -1,3 +1,4 @@
+
 Data specific to this indicator.
 
 ```{r}
@@ -19,9 +20,7 @@ emissions_profile <- profile_emissions(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/extdata/code-profile_emissions_upstream.Rmd
+++ b/inst/extdata/code-profile_emissions_upstream.Rmd
@@ -1,3 +1,4 @@
+
 Data specific to this indicator.
 
 ```{r}
@@ -20,9 +21,7 @@ emissions_profile_upstream <- profile_emissions_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/extdata/code-profile_sector.Rmd
+++ b/inst/extdata/code-profile_sector.Rmd
@@ -1,3 +1,4 @@
+
 Data specific to this indicator.
 
 ```{r}

--- a/inst/extdata/code-profile_sector.Rmd
+++ b/inst/extdata/code-profile_sector.Rmd
@@ -16,9 +16,7 @@ sector_profile <- profile_sector(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/extdata/code-profile_sector_upstream.Rmd
+++ b/inst/extdata/code-profile_sector_upstream.Rmd
@@ -19,9 +19,7 @@ sector_profile_upstream <- profile_sector_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/extdata/code-profile_sector_upstream.Rmd
+++ b/inst/extdata/code-profile_sector_upstream.Rmd
@@ -1,3 +1,4 @@
+
 Data specific to this indicator.
 
 ```{r}

--- a/inst/templates/profile_emissions.Rmd
+++ b/inst/templates/profile_emissions.Rmd
@@ -109,6 +109,7 @@ ecoinvent_activities <- read_csv(path(params$input, params$ecoinvent_activities)
 ecoinvent_europages <- read_csv(path(params$input, params$ecoinvent_europages))
 isic <- read_csv(path(params$input, params$isic))
 ```
+
 Data specific to this indicator.
 
 ```{r}
@@ -130,9 +131,7 @@ emissions_profile <- profile_emissions(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/templates/profile_emissions_upstream.Rmd
+++ b/inst/templates/profile_emissions_upstream.Rmd
@@ -115,6 +115,7 @@ The "upstream" workflows also need this dataset.
 ```{r}
 ecoinvent_inputs <- read_csv(path(params$input, params$ecoinvent_inputs))
 ```
+
 Data specific to this indicator.
 
 ```{r}
@@ -137,9 +138,7 @@ emissions_profile_upstream <- profile_emissions_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -109,6 +109,7 @@ ecoinvent_activities <- read_csv(path(params$input, params$ecoinvent_activities)
 ecoinvent_europages <- read_csv(path(params$input, params$ecoinvent_europages))
 isic <- read_csv(path(params$input, params$isic))
 ```
+
 Data specific to this indicator.
 
 ```{r}

--- a/inst/templates/profile_sector.Rmd
+++ b/inst/templates/profile_sector.Rmd
@@ -127,9 +127,7 @@ sector_profile <- profile_sector(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -116,6 +116,7 @@ The "upstream" workflows also need this dataset.
 ```{r}
 ecoinvent_inputs <- read_csv(path(params$input, params$ecoinvent_inputs))
 ```
+
 Data specific to this indicator.
 
 ```{r}

--- a/inst/templates/profile_sector_upstream.Rmd
+++ b/inst/templates/profile_sector_upstream.Rmd
@@ -137,9 +137,7 @@ sector_profile_upstream <- profile_sector_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/man/profile_emissions.Rd
+++ b/man/profile_emissions.Rd
@@ -37,6 +37,12 @@ profile products.}
 }
 \value{
 A data frame with the column \code{companies_id}, and the nested columns\code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
+
+The columns \code{co2e_lower} and \code{co2e_upper} show the lowest and highest value
+of \code{co2_footprint} within the group to which the product was compared, plus
+some randomness. Therefore, every benchmark can have different \code{co2e_lower}
+and \code{co2e_upper}, because every benchmark can contain a different set of
+products.
 }
 \description{
 These functions wrap the output of the corresponding function in
@@ -44,12 +50,14 @@ These functions wrap the output of the corresponding function in
 }
 \examples{
 library(tiltToyData)
+library(withr)
 library(readr, warn.conflicts = FALSE)
 
-options(readr.show_col_types = FALSE)
+local_seed(1)
+local_options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_emissions_profile_products())
+products <- read_csv(toy_emissions_profile_products_ecoinvent())
 europages_companies <- read_csv(toy_europages_companies())
 ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
 ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
@@ -70,7 +78,7 @@ result |> unnest_company()
 
 
 
-inputs <- read_csv(toy_emissions_profile_upstream_products())
+inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
 ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
 
 result <- profile_emissions_upstream(

--- a/man/profile_emissions_upstream.Rd
+++ b/man/profile_emissions_upstream.Rd
@@ -40,6 +40,12 @@ profile products.}
 }
 \value{
 A data frame with the column \code{companies_id}, and the nested columns\code{product} and \code{company} holding the outputs at product and company level. Unnesting \code{product} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}. Unnesting \code{company} yields a data frame with at least columns \code{companies_id}, \code{grouped_by}, \code{risk_category}, \code{value}.
+
+The columns \code{co2e_lower} and \code{co2e_upper} show the lowest and highest value
+of \code{co2_footprint} within the group to which the product was compared, plus
+some randomness. Therefore, every benchmark can have different \code{co2e_lower}
+and \code{co2e_upper}, because every benchmark can contain a different set of
+products.
 }
 \description{
 These functions wrap the output of the corresponding function in
@@ -47,12 +53,14 @@ These functions wrap the output of the corresponding function in
 }
 \examples{
 library(tiltToyData)
+library(withr)
 library(readr, warn.conflicts = FALSE)
 
-options(readr.show_col_types = FALSE)
+local_seed(1)
+local_options(readr.show_col_types = FALSE)
 
 companies <- read_csv(toy_emissions_profile_any_companies())
-products <- read_csv(toy_emissions_profile_products())
+products <- read_csv(toy_emissions_profile_products_ecoinvent())
 europages_companies <- read_csv(toy_europages_companies())
 ecoinvent_activities <- read_csv(toy_ecoinvent_activities())
 ecoinvent_europages <- read_csv(toy_ecoinvent_europages())
@@ -73,7 +81,7 @@ result |> unnest_company()
 
 
 
-inputs <- read_csv(toy_emissions_profile_upstream_products())
+inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent())
 ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs())
 
 result <- profile_emissions_upstream(

--- a/vignettes/articles/profile_emissions.Rmd
+++ b/vignettes/articles/profile_emissions.Rmd
@@ -109,6 +109,7 @@ ecoinvent_activities <- read_csv(path(params$input, params$ecoinvent_activities)
 ecoinvent_europages <- read_csv(path(params$input, params$ecoinvent_europages))
 isic <- read_csv(path(params$input, params$isic))
 ```
+
 Data specific to this indicator.
 
 ```{r}
@@ -130,9 +131,7 @@ emissions_profile <- profile_emissions(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/vignettes/articles/profile_emissions_upstream.Rmd
+++ b/vignettes/articles/profile_emissions_upstream.Rmd
@@ -115,6 +115,7 @@ The "upstream" workflows also need this dataset.
 ```{r}
 ecoinvent_inputs <- read_csv(path(params$input, params$ecoinvent_inputs))
 ```
+
 Data specific to this indicator.
 
 ```{r}
@@ -137,9 +138,7 @@ emissions_profile_upstream <- profile_emissions_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -109,6 +109,7 @@ ecoinvent_activities <- read_csv(path(params$input, params$ecoinvent_activities)
 ecoinvent_europages <- read_csv(path(params$input, params$ecoinvent_europages))
 isic <- read_csv(path(params$input, params$isic))
 ```
+
 Data specific to this indicator.
 
 ```{r}

--- a/vignettes/articles/profile_sector.Rmd
+++ b/vignettes/articles/profile_sector.Rmd
@@ -127,9 +127,7 @@ sector_profile <- profile_sector(
   europages_companies = europages_companies,
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -116,6 +116,7 @@ The "upstream" workflows also need this dataset.
 ```{r}
 ecoinvent_inputs <- read_csv(path(params$input, params$ecoinvent_inputs))
 ```
+
 Data specific to this indicator.
 
 ```{r}

--- a/vignettes/articles/profile_sector_upstream.Rmd
+++ b/vignettes/articles/profile_sector_upstream.Rmd
@@ -137,9 +137,7 @@ sector_profile_upstream <- profile_sector_upstream(
   ecoinvent_activities = ecoinvent_activities,
   ecoinvent_inputs = ecoinvent_inputs,
   ecoinvent_europages = ecoinvent_europages,
-  isic = isic,
-  low_threshold = 1 / 3,
-  high_threshold = 2 / 3
+  isic = isic
 )
 ```
 


### PR DESCRIPTION
Closes #140

This PR changes removes `*threshold` from the call to each `profile*()`. This makes it safer to run the workflows 'as is'. Whenever we change the defaults upstream (e.g. tiltIndicator) we don't need to remember to change the workflows.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
