### PR TITLE
Warn when using threshold arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ input
 output
 vignettes/articles/input
 vignettes/articles/output
-real/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ input
 output
 vignettes/articles/input
 vignettes/articles/output
+real/

--- a/R/profile.R
+++ b/R/profile.R
@@ -18,6 +18,8 @@ profile_emissions <- function(companies,
     isic <- isic_tilt
   }
 
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -74,6 +76,8 @@ profile_emissions_upstream <- function(companies,
     )
     isic <- isic_tilt
   }
+
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
 
   op <- enlist_options()
   chunks <- op$chunks
@@ -133,6 +137,8 @@ profile_sector <- function(companies,
     isic <- isic_tilt
   }
 
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
+
   op <- enlist_options()
   chunks <- op$chunks
   cache_dir <- op$cache_dir
@@ -190,6 +196,8 @@ profile_sector_upstream <- function(companies,
     )
     isic <- isic_tilt
   }
+
+  if (!missing(low_threshold) || !missing(high_threshold)) warn_thresholds()
 
   op <- enlist_options()
   chunks <- op$chunks

--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -9,3 +9,12 @@ companies <- memoise::memoise(function() {
 products <- memoise::memoise(function() {
   read_csv(toy_emissions_profile_products())
 })
+
+verbose <- function() {
+  # Inspired by https://ropensci.org/blog/2024/02/06/verbosity-control-packages/#how-to-implement-package-level-verbosity-control-in-your-package
+  getOption("tiltWorkflows.verbose", default = TRUE)
+}
+
+read_test_csv <- function(file, ..., show_col_types = FALSE, n_max = 1) {
+  read_csv(file, show_col_types = show_col_types, n_max = n_max)
+}

--- a/R/utils-test.R
+++ b/R/utils-test.R
@@ -10,11 +10,6 @@ products <- memoise::memoise(function() {
   read_csv(toy_emissions_profile_products())
 })
 
-verbose <- function() {
-  # Inspired by https://ropensci.org/blog/2024/02/06/verbosity-control-packages/#how-to-implement-package-level-verbosity-control-in-your-package
-  getOption("tiltWorkflows.verbose", default = TRUE)
-}
-
 read_test_csv <- function(file, ..., show_col_types = FALSE, n_max = 1) {
   read_csv(file, show_col_types = show_col_types, n_max = n_max)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,3 +5,14 @@ extract_options <- function(pattern) {
 tiltIndicatorAfter_options <- function() {
   extract_options("tiltIndicatorAfter")
 }
+
+warn_thresholds <- function() {
+  # if (!verbose()) {
+  #   return()
+  # }
+
+  rlang::warn(c(
+    "The default thresholds are generally the most useful.",
+    i = "Do you really need to adjust them?"
+  ))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,10 +7,6 @@ tiltIndicatorAfter_options <- function() {
 }
 
 warn_thresholds <- function() {
-  # if (!verbose()) {
-  #   return()
-  # }
-
   rlang::warn(c(
     "The default thresholds are generally the most useful.",
     i = "Do you really need to adjust them?"

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@ tiltIndicatorAfter_options <- function() {
 }
 
 warn_thresholds <- function() {
-  rlang::warn(c(
+  warn(c(
     "The default thresholds are generally the most useful.",
     i = "Do you really need to adjust them?"
   ))

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -294,12 +294,12 @@ test_that("warns if using `*threshold`", {
     tiltWorkflows.chunks = 1
   ))
 
-  companies <- read_csv(toy_emissions_profile_any_companies()) |> head(1)
-  products <- read_csv(toy_emissions_profile_products_ecoinvent()) |> head(1)
-  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
-  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
-  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
-  isic_name <- read_csv(toy_isic_name()) |> head(1)
+  companies <- read_test_csv(toy_emissions_profile_any_companies())
+  products <- read_test_csv(toy_emissions_profile_products_ecoinvent())
+  europages_companies <- read_test_csv(toy_europages_companies())
+  ecoinvent_activities <- read_test_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_test_csv(toy_ecoinvent_europages())
+  isic_name <- read_test_csv(toy_isic_name())
 
   expect_no_warning(
     profile_emissions(
@@ -325,8 +325,8 @@ test_that("warns if using `*threshold`", {
     "threshold.*adjust"
   )
 
-  inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent()) |> head(1)
-  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs()) |> head(1)
+  inputs <- read_test_csv(toy_emissions_profile_upstream_products_ecoinvent())
+  ecoinvent_inputs <- read_test_csv(toy_ecoinvent_inputs())
   expect_warning(
     profile_emissions_upstream(
       companies,
@@ -341,12 +341,12 @@ test_that("warns if using `*threshold`", {
     "threshold.*adjust"
   )
 
-  companies <- read_csv(toy_sector_profile_companies()) |> head(1)
-  scenarios <- read_csv(toy_sector_profile_any_scenarios()) |> head(1)
-  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
-  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
-  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
-  isic_name <- read_csv(toy_isic_name()) |> head(1)
+  companies <- read_test_csv(toy_sector_profile_companies())
+  scenarios <- read_test_csv(toy_sector_profile_any_scenarios())
+  europages_companies <- read_test_csv(toy_europages_companies())
+  ecoinvent_activities <- read_test_csv(toy_ecoinvent_activities())
+  ecoinvent_europages <- read_test_csv(toy_ecoinvent_europages())
+  isic_name <- read_test_csv(toy_isic_name())
   expect_warning(
     profile_sector(
       companies,
@@ -360,14 +360,14 @@ test_that("warns if using `*threshold`", {
     "threshold.*adjust"
   )
 
-  companies <- read_csv(toy_sector_profile_upstream_companies()) |> head(1)
-  scenarios <- read_csv(toy_sector_profile_any_scenarios()) |> head(1)
-  inputs <- read_csv(toy_sector_profile_upstream_products()) |> head(1)
-  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
-  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
-  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs()) |> head(1)
-  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
-  isic_name <- read_csv(toy_isic_name()) |> head(1)
+  companies <- read_test_csv(toy_sector_profile_upstream_companies())
+  scenarios <- read_test_csv(toy_sector_profile_any_scenarios())
+  inputs <- read_test_csv(toy_sector_profile_upstream_products())
+  europages_companies <- read_test_csv(toy_europages_companies())
+  ecoinvent_activities <- read_test_csv(toy_ecoinvent_activities())
+  ecoinvent_inputs <- read_test_csv(toy_ecoinvent_inputs())
+  ecoinvent_europages <- read_test_csv(toy_ecoinvent_europages())
+  isic_name <- read_test_csv(toy_isic_name())
   expect_warning(
     profile_sector_upstream(
       companies,

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -287,3 +287,99 @@ test_that("can optionally output `co2_*` columns", {
   expect_true(hasName(unnest_product(out), "co2_footprint"))
   expect_true(hasName(unnest_company(out), "co2_avg"))
 })
+
+test_that("warns if using `*threshold`", {
+  local_options(list(
+    tiltWorkflows.cache_dir = withr::local_tempdir(),
+    tiltWorkflows.chunks = 1
+  ))
+
+  companies <- read_csv(toy_emissions_profile_any_companies()) |> head(1)
+  products <- read_csv(toy_emissions_profile_products_ecoinvent()) |> head(1)
+  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
+  isic_name <- read_csv(toy_isic_name()) |> head(1)
+
+  expect_no_warning(
+    profile_emissions(
+      companies,
+      products,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name
+    )
+  )
+
+  expect_warning(
+    profile_emissions(
+      companies,
+      products,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name,
+      low_threshold = 1/4
+    ),
+    "threshold.*adjust"
+  )
+
+  inputs <- read_csv(toy_emissions_profile_upstream_products_ecoinvent()) |> head(1)
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs()) |> head(1)
+  expect_warning(
+    profile_emissions_upstream(
+      companies,
+      inputs,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_inputs = ecoinvent_inputs,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name,
+      low_threshold = 1/4
+    ),
+    "threshold.*adjust"
+  )
+
+  companies <- read_csv(toy_sector_profile_companies()) |> head(1)
+  scenarios <- read_csv(toy_sector_profile_any_scenarios()) |> head(1)
+  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
+  isic_name <- read_csv(toy_isic_name()) |> head(1)
+  expect_warning(
+    profile_sector(
+      companies,
+      scenarios,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name,
+      low_threshold = 1 / 4
+    ),
+    "threshold.*adjust"
+  )
+
+  companies <- read_csv(toy_sector_profile_upstream_companies()) |> head(1)
+  scenarios <- read_csv(toy_sector_profile_any_scenarios()) |> head(1)
+  inputs <- read_csv(toy_sector_profile_upstream_products()) |> head(1)
+  europages_companies <- read_csv(toy_europages_companies()) |> head(1)
+  ecoinvent_activities <- read_csv(toy_ecoinvent_activities()) |> head(1)
+  ecoinvent_inputs <- read_csv(toy_ecoinvent_inputs()) |> head(1)
+  ecoinvent_europages <- read_csv(toy_ecoinvent_europages()) |> head(1)
+  isic_name <- read_csv(toy_isic_name()) |> head(1)
+  expect_warning(
+    profile_sector_upstream(
+      companies,
+      scenarios,
+      inputs,
+      europages_companies = europages_companies,
+      ecoinvent_activities = ecoinvent_activities,
+      ecoinvent_inputs = ecoinvent_inputs,
+      ecoinvent_europages = ecoinvent_europages,
+      isic = isic_name,
+      low_threshold = 1 / 4
+    ),
+    "threshold.*adjust"
+  )
+})


### PR DESCRIPTION
Closes 2DegreesInvesting/tiltIndicator#753

I implemented this feature here since it's simpler to implement, and seems like a better place -- as this package aims to be the most user-friendly.

@Tilmon here's a reprex showing the new feature:

<details/>
<summary/>
reprex
</summary>

``` r
devtools::load_all()
#> ℹ Loading tiltWorkflows
#> Loading required package: tiltIndicatorAfter
#> 
#> Loading required package: tiltToyData

local_options(list(
  tiltWorkflows.cache_dir = withr::local_tempdir(),
  tiltWorkflows.chunks = 1,
  tiltIndicatorAfter.verbose = FALSE
))

read <- function(file) readr::read_csv(file, show_col_types = FALSE, n_max = 1)

companies <- read(toy_sector_profile_upstream_companies())
scenarios <- read(toy_sector_profile_any_scenarios())
inputs <- read(toy_sector_profile_upstream_products())
europages_companies <- read(toy_europages_companies())
ecoinvent_activities <- read(toy_ecoinvent_activities())
ecoinvent_inputs <- read(toy_ecoinvent_inputs())
ecoinvent_europages <- read(toy_ecoinvent_europages())
isic_name <- read(toy_isic_name())

# If you don't use the `*threshold` arguments you get the defaults and no warning
out <- profile_sector_upstream(
  companies,
  scenarios,
  inputs,
  europages_companies = europages_companies,
  ecoinvent_activities = ecoinvent_activities,
  ecoinvent_inputs = ecoinvent_inputs,
  ecoinvent_europages = ecoinvent_europages,
  isic = isic_name
)

# If you DO use `*threshold` you get a warning
out <- profile_sector_upstream(
  companies,
  scenarios,
  inputs,
  europages_companies = europages_companies,
  ecoinvent_activities = ecoinvent_activities,
  ecoinvent_inputs = ecoinvent_inputs,
  ecoinvent_europages = ecoinvent_europages,
  isic = isic_name,
  low_threshold = 1/4
)
#> Warning: The default thresholds are generally the most useful.
#> ℹ Do you really need to adjust them?

companies <- read(toy_emissions_profile_any_companies())
products <- read(toy_emissions_profile_products_ecoinvent())
europages_companies <- read(toy_europages_companies())
ecoinvent_activities <- read(toy_ecoinvent_activities())
ecoinvent_europages <- read(toy_ecoinvent_europages())
isic_name <- read(toy_isic_name())

# The same goes for all indicators and even if the value you pass is the same
# as the default (not ideal but good enough and simplest to implement).

# See all defaults
formals(profile_emissions)
#> $companies
#> 
#> 
#> $co2
#> 
#> 
#> $europages_companies
#> 
#> 
#> $ecoinvent_activities
#> 
#> 
#> $ecoinvent_europages
#> 
#> 
#> $isic
#> 
#> 
#> $isic_tilt
#> lifecycle::deprecated()
#> 
#> $low_threshold
#> 1/3
#> 
#> $high_threshold
#> 2/3
# Use the default high_threshold
default <- 2/3
out <- profile_emissions(
  companies,
  products,
  europages_companies = europages_companies,
  ecoinvent_activities = ecoinvent_activities,
  ecoinvent_europages = ecoinvent_europages,
  isic = isic_name,
  high_threshold = default
)
#> Warning: The default thresholds are generally the most useful.
#> ℹ Do you really need to adjust them?
```

</details>


----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
